### PR TITLE
Adds feature to customize the main seeder class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The purpose of this package is to make it easier for the developers to run seede
 
 ## Assumption
 
-This package assumes that you use `DatabaseSeeder` class as the parent for running all other seeders. The `DatabaseSeeder` should never seed any data directly on its own. It should only be used to run other seeder classes.
+This package assumes that you use one seeder (ex.`DatabaseSeeder`) class as the main/parent for running all other seeders. This main seeder class should never seed any data directly on its own. It should only be used to run other seeder classes.
 
 ## Installation
 
@@ -32,9 +32,16 @@ php artisan migrate
 
 Note: This will create a table named `seeders` in your database. If you want to change this table's name, then you have to publish the package's config (above step) and modify the value of `table` in `config/seedonce.php`.
 
+## Configuration
+
+Once you have published the configuration file, you can edit it to suit your needs. Configuration options are as follows:
+
+- `table`: This is the name of the table that will hold the details of the seeders that have been executed. The default value is *seeders* which should work in most of the cases.
+- `database_seeder`: This is the name of the class that seeds all other seeders. In most of the cases this will be *DatabaseSeeder* which is the default value. Make sure to change this if you use a different class as the entry point to seed all other seeders.
+
 ## Usage
 
-Use the `Ranium\SeedOnce\Traits\SeedOnce` trait in all your seeder classes including the `DatabaseSeeder` class.
+Use the `Ranium\SeedOnce\Traits\SeedOnce` trait in all your seeder classes including the main seeder (ex. `DatabaseSeeder`) class.
 
 ```
 <?php

--- a/config/seedonce.php
+++ b/config/seedonce.php
@@ -11,6 +11,16 @@ return [
     | seeders that have been executed.
     |
     */
-
     'table' => 'seeders',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Main Database Seeder class name
+    |--------------------------------------------------------------------------
+    |
+    | This value is the name of the class that seeds all other seeders.
+    | In most of the cases this will be DatabaseSeeder.
+    |
+    */
+    'database_seeder' => 'DatabaseSeeder',
 ];

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -64,7 +64,7 @@ class BaseCommand extends Command
 
     /**
      * Get the seeders to mark as seeded.
-     * NOTE: DatabaseSeeder is always excluded.
+     * NOTE: Main Database Seeder is always excluded.
      *
      * @param string $classOption Which class to get. "all" for all classes.
      * @return array
@@ -83,7 +83,7 @@ class BaseCommand extends Command
                 // Filter out classes based on option passed
                 return ($classOption === 'all' || $classOption === $class)
                     // We want to skip DatabaseSeeder as we never mark it as seeded
-                    && $class !== 'DatabaseSeeder';
+                    && $class !== config('seedonce.database_seeder');
             });
     }
 

--- a/src/Traits/SeedOnce.php
+++ b/src/Traits/SeedOnce.php
@@ -71,10 +71,10 @@ trait SeedOnce {
      */
     protected function markSeeded($class)
     {
-        // We will mark class as seeded only if it is not DatabaseSeeder class.
-        // We are assuming that DatabaseSeeder never seeds directly and
+        // We will mark class as seeded only if it is not parent Database Seeder class.
+        // database_seeder class set in config never seeds directly and
         // always calls other seeder classes to seed.
-        if ($class !== 'DatabaseSeeder') {
+        if ($class !== config('seedonce.database_seeder')) {
             $this->repository()->log($class);
         }
     }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -6,19 +6,33 @@ use Illuminate\Support\Facades\Schema;
 class ConfigTest extends TestCase
 {
     /**
-     * Define environment setup.
+     * Define environment setup for custom table
      *
      * @param  \Illuminate\Foundation\Application  $app
      *
      * @return void
      */
-    protected function getEnvironmentSetUp($app)
+    protected function useCustomTable($app)
     {
-        $app['config']->set('seedonce.table', 'my_seeders');
-        parent::getEnvironmentSetUp($app);
+        $app->config->set('seedonce.table', 'my_seeders');
     }
 
-    /** @test */
+    /**
+     * Define environment setup for custom database seeder
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     *
+     * @return void
+     */
+    protected function useCustomDatabaseSeeder($app)
+    {
+        $app->config->set('seedonce.database_seeder', 'MyDatabaseSeeder');
+    }
+
+    /**
+     * @test
+     * @environment-setup useCustomTable
+     */
     public function it_can_have_seeder_table_name()
     {
         $table = 'my_seeders';
@@ -33,6 +47,21 @@ class ConfigTest extends TestCase
 
         $this->assertDatabaseHas($table, [
             'seeder' => 'RolesTableSeeder'
+        ]);
+    }
+
+    /**
+     * @test
+     * @environment-setup useCustomDatabaseSeeder
+     */
+    public function it_can_have_database_seeder_name()
+    {
+        $this->artisan('db:seed')->run();
+
+        // Since we changed the name of database_seeder (in useCustomDatabaseSeeder),
+        // the seeders table should have the default DatabaseSeeder marked as seeded.
+        $this->assertDatabaseHas('seeders', [
+            'seeder' => 'DatabaseSeeder'
         ]);
     }
 }

--- a/tests/SeedOnceTest.php
+++ b/tests/SeedOnceTest.php
@@ -20,6 +20,10 @@ class SeedOnceTest extends TestCase
         $this->assertDatabaseHas('seeders', [
             'seeder' => 'UsersTableSeeder'
         ]);
+
+        $this->assertDatabaseMissing('seeders', [
+            'seeder' => config('seedonce.database_seeder')
+        ]);
     }
 
     /** @test */


### PR DESCRIPTION
- Added a new config variable `database_seeder` with default value `DatabaseSeeder`
- Users can change the value of this config variable to their main database seeder class name if they are not using the default `DatabaseSeeder` as their main seeder.