### PR TITLE
Refactored equal to contains on Base Command

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -127,11 +127,11 @@ class BaseCommand extends Command
     {
         $composerJsonPath = base_path('composer.json');
         $composerConfig = json_decode(file_get_contents($composerJsonPath), true);
-        $relativeSeederPath = str_replace($this->laravel->databasePath() . DIRECTORY_SEPARATOR, '', $this->getSeederFolder());
+        $seederConfigPath = config('seedonce.folder_seeder');
 
         if ((float) app()->version() >= 8) {
-            $items = array_filter($composerConfig['autoload']['psr-4'], function ($item) use ($relativeSeederPath) {
-                return $item === $relativeSeederPath;
+            $items = array_filter($composerConfig['autoload']['psr-4'], function ($item) use ($seederConfigPath) {
+                return Str::contains($item, $seederConfigPath);
             });
 
             return array_keys($items)[0] ?? '';


### PR DESCRIPTION
Refactored equal to contains on Base Command

-- 
I refactored this, because in an installation where there was the seed path via composer.json it gave an error.

with this change it does not validate the prefix "database"